### PR TITLE
feat(rk-llama): NPU-accelerated llama.cpp on rk8s (rock-5b-01)

### DIFF
--- a/apps/rk-llama/Containerfile
+++ b/apps/rk-llama/Containerfile
@@ -1,0 +1,13 @@
+FROM docker.io/library/debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcurl4 libgomp1 ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY bin/ /usr/local/rk-llama/
+
+ENV LD_LIBRARY_PATH=/usr/local/rk-llama
+ENV PATH=/usr/local/rk-llama:$PATH
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/rk-llama/llama-server"]

--- a/apps/rk-llama/README.md
+++ b/apps/rk-llama/README.md
@@ -1,0 +1,77 @@
+# rk-llama
+
+llama.cpp with the Rockchip NPU (RKNPU2) GGML backend, serving
+Ministral-3-3B on the rk8s cluster.
+
+Upstream: <https://github.com/invisiofficial/rk-llama.cpp> branch
+`rknpu2` (commit `81eff6a` at time of build).
+
+## Node prerequisites (rock-5b-01)
+
+The vendor RKNN runtime (`librknnrt.so`) only works against the
+Armbian **vendor** kernel's rknpu driver — not the mainline `rocket`
+driver the rest of the boards run. rock-5b-01 was switched to
+`linux-image-vendor-rk35xx` (6.1.115, rknpu v0.9.8). Note the boards
+PXE-load their kernels from rb5009, so the vendor kernel had to be
+staged to `sbc/armbian/rock-5b-01.igou.systems/{vmlinuz,initrd.img,board.dtb}`
+on the router in addition to the apt install.
+
+Model files on the node:
+
+```
+/var/lib/rk-llama/models/Ministral-3-3B-Instruct-2512-Q8_0.gguf  # served
+/var/lib/rk-llama/models/gemma-4-E4B-it-Q8_0.gguf                # broken on fork, kept
+/var/lib/rk-llama/models/LFM2-8B-A1B-Q8_0.gguf                   # broken on fork, kept
+```
+
+Q8_0 was chosen deliberately: the backend requantizes GGUF weights
+into NPU-native formats, and Q8_0 → W8A8 is the recommended pairing
+(precision levels match).
+
+**Model selection findings** (driver v0.9.8, librknnrt 2.3.2 — the
+fork bundles exactly the official v2.3.2 runtime):
+
+- **Gemma-4-E4B** (the original goal): loads and generates at full
+  speed (pp64 39 t/s, tg16 3.4 t/s) but produces degenerate
+  prompt-echo output. The gemma3n/gemma4-E architecture family is
+  broken in this fork (upstream issue #6); gemma-3-1b is broken
+  even on the pure-CPU fallback pipeline. W8A8_STANDARD,
+  W8A8_HADAMARD, and single-core NPU all tried.
+- **LFM2-8B-A1B**: generates only special tokens despite being in
+  the fork's benchmark table.
+- **Granite-4.0-350M / Ministral-3-3B**: fully coherent output on
+  the default W8A8 NPU pipeline — the NPU stack itself is healthy.
+
+Retest the broken GGUFs (kept on the node) after upstream fixes.
+
+## Image
+
+Built from `Containerfile` in this directory. The binaries are
+compiled natively on a board (`cmake -DLLAMA_RKNPU2=ON`) and copied
+in; no registry is involved — the image is imported straight into
+k3s containerd on the target node:
+
+```
+podman build --arch arm64 -t localhost/rk-llama-server:rknpu2-<sha> .
+podman save -o rk-llama-image.tar localhost/rk-llama-server:rknpu2-<sha>
+scp rk-llama-image.tar igou@rock-5b-01.igou.systems:/tmp/
+ssh igou@rock-5b-01.igou.systems sudo k3s ctr images import /tmp/rk-llama-image.tar
+```
+
+## Caveats
+
+- **One NPU client at a time.** Concurrent independent processes on
+  the NPU can kernel-panic the board (upstream README), hence
+  `replicas: 1` + `Recreate`.
+- The NPU has a 4GB-per-IOMMU-domain limit; the backend spreads
+  larger models across domains automatically (`RKNPU_DOMAINS` to
+  partition manually).
+- A daily `system_update` run on the boards can upgrade kernel
+  packages on disk; the *booted* kernel comes from rb5009 TFTP, so
+  module/kernel BTF mismatches reappear if the staged TFTP kernel is
+  not refreshed alongside.
+
+## Access
+
+`http://rock-5b-01.igou.systems:30808/` (NodePort) — llama-server
+web UI and OpenAI-compatible API at `/v1/chat/completions`.

--- a/apps/rk-llama/deployment.yaml
+++ b/apps/rk-llama/deployment.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rk-llama-server
+  namespace: rk-llama
+  labels:
+    app.kubernetes.io/name: rk-llama-server
+spec:
+  # The RK3588 NPU kernel-panics if two independent processes touch it
+  # concurrently (per upstream README), so never surge a second pod.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rk-llama-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rk-llama-server
+    spec:
+      # Pinned to the one board running the Armbian vendor kernel
+      # (6.1.115-vendor-rk35xx), which provides the rknpu driver
+      # (v0.9.8) that librknnrt requires. The other boards run
+      # mainline/edge kernels whose `rocket` driver cannot serve
+      # the vendor RKNN runtime.
+      nodeSelector:
+        kubernetes.io/hostname: rock-5b-01.igou.systems
+      containers:
+        - name: llama-server
+          # Built from the Containerfile in this directory; binaries
+          # compiled natively on a board from
+          # github.com/invisiofficial/rk-llama.cpp @ rknpu2 (81eff6a).
+          # Imported into k3s containerd on the node via
+          # `k3s ctr images import` (no registry), hence Never.
+          image: localhost/rk-llama-server:rknpu2-81eff6a
+          imagePullPolicy: Never
+          args:
+            # Ministral-3-3B after two failed candidates: Gemma-4-E4B
+            # (gemma3n/gemma4-E family generates degenerate output on
+            # this fork — upstream issue #6) and LFM2-8B-A1B (special
+            # tokens only). Both of those GGUFs remain on the node for
+            # retesting when upstream fixes land. Ministral3 3B is
+            # all-green in the fork's own benchmark table and verified
+            # coherent here on the W8A8 NPU pipeline.
+            - "-m"
+            - "/models/Ministral-3-3B-Instruct-2512-Q8_0.gguf"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "-c"
+            - "4096"
+          env:
+            # Q8_0 maps to the W8A8_STANDARD pipeline by default —
+            # the exact config upstream benchmarked for this model.
+            - name: RKNPU_DEVICE
+              value: "RK3588"
+          securityContext:
+            # librknnrt needs raw access to the rknpu DRM render node
+            # and DMA heaps; privileged keeps this simple on a
+            # single-user homelab cluster.
+            privileged: true
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: models
+              mountPath: /models
+              readOnly: true
+            - name: dev-dri
+              mountPath: /dev/dri
+          resources:
+            requests:
+              cpu: "2"
+              memory: 5Gi
+            limits:
+              memory: 8Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            # Model load + NPU requantization takes minutes.
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 900
+            periodSeconds: 30
+            failureThreshold: 10
+      volumes:
+        - name: models
+          hostPath:
+            path: /var/lib/rk-llama/models
+            type: Directory
+        - name: dev-dri
+          hostPath:
+            path: /dev/dri
+            type: Directory

--- a/apps/rk-llama/kustomization.yaml
+++ b/apps/rk-llama/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/rk-llama/namespace.yaml
+++ b/apps/rk-llama/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rk-llama
+  labels:
+    app.kubernetes.io/name: rk-llama

--- a/apps/rk-llama/service.yaml
+++ b/apps/rk-llama/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rk-llama-server
+  namespace: rk-llama
+  labels:
+    app.kubernetes.io/name: rk-llama-server
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: rk-llama-server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      nodePort: 30808

--- a/bootstrap/applications/external/rk-llama-application.yml
+++ b/bootstrap/applications/external/rk-llama-application.yml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rk-llama
+  namespace: argocd
+spec:
+  destination:
+    namespace: rk-llama
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: apps/rk-llama
+    repoURL: https://github.com/igou-io/igou-kubernetes.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true


### PR DESCRIPTION
## What
Deploys [invisiofficial/rk-llama.cpp](https://github.com/invisiofficial/rk-llama.cpp) (RKNPU2 GGML backend) serving **Ministral-3-3B-Instruct Q8_0** on the Rockchip NPU of `rock-5b-01`. Verified end-to-end via NodePort 30808 (OpenAI-compatible API + web UI).

## Contents
- `apps/rk-llama/` — namespace, deployment, service, kustomization, `Containerfile`, README.
- `bootstrap/applications/external/rk-llama-application.yml` — ArgoCD Application (auto-sync + prune).

## Node prerequisites (rock-5b-01 only)
Switched to the Armbian **vendor** kernel (`linux-image-vendor-rk35xx`, rknpu driver v0.9.8) so the vendor `librknnrt` can reach the NPU — the rest of the fleet runs mainline kernels whose `rocket` driver cannot. The image is built natively on a board and imported into k3s containerd (no registry), hence `imagePullPolicy: Never`.

## Model selection findings
- **Gemma-4-E4B** (original goal) and **LFM2-8B-A1B** both load and run on the NPU but emit garbage (gemma family = upstream issue #6). GGUFs kept on the node for retest — tracked in #870.
- **Ministral-3-3B** / Granite-350M produce coherent output → Ministral-3-3B is the served model.

## Caveats
- One NPU client at a time (concurrent access kernel-panics the board) → `replicas: 1` + `Recreate`.
- `rock-5b-01` kernel divergence + TFTP resync fragility tracked in #871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)