### PR TITLE
fix(metallb): range pools excluding .0/.255, pin .1 for the gateway

### DIFF
--- a/components/metallb/bgp-advertisement.yaml
+++ b/components/metallb/bgp-advertisement.yaml
@@ -10,5 +10,6 @@ metadata:
 spec:
   ipAddressPools:
     - trusted-lan
+    - trusted-lan-gateway
     - iot
     - guest-dmz

--- a/components/metallb/ipaddresspools.yaml
+++ b/components/metallb/ipaddresspools.yaml
@@ -12,8 +12,24 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   addresses:
-    - 10.10.150.0/24
+    # .1 is reserved for the cluster gateway (DNS *.rk8s.igou.systems);
+    # exclude it and the network/broadcast addresses from auto-assignment.
+    - 10.10.150.2-10.10.150.254
   autoAssign: true
+---
+# Pinned pool for the gateway VIP: request it with
+# metallb.io/loadBalancerIPs: 10.10.150.1 (or spec.loadBalancerIP).
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: trusted-lan-gateway
+  namespace: metallb-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  addresses:
+    - 10.10.150.1/32
+  autoAssign: false
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -24,7 +40,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   addresses:
-    - 10.10.151.0/24
+    - 10.10.151.1-10.10.151.254
   autoAssign: false
 ---
 apiVersion: metallb.io/v1beta1
@@ -36,5 +52,5 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   addresses:
-    - 10.10.152.0/24
+    - 10.10.152.1-10.10.152.254
   autoAssign: false


### PR DESCRIPTION
Found during the live end-to-end LB test after #872 bootstrapped rk8s: the first auto-assignment handed out **10.10.150.0** (the network address — worked via BGP/curl, but flaky with some network gear, and it means the DNS-reserved `.1` sits in the rotation).

- Tier pools become `.2-.254` ranges (network/broadcast excluded, `.1` carved out).
- New `trusted-lan-gateway` pool holds `10.10.150.1/32` with `autoAssign: false` — the Gateway requests it via `metallb.io/loadBalancerIPs: 10.10.150.1` (`*.rk8s.igou.systems` + apex already resolve there).
- Added to the BGPAdvertisement.

Cluster state: all 6 nodes Established with rb5009, ClusterSecretStore Valid, e2e LB curl verified (test service removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)