### PR TITLE
fix(kubevirt): bump CDI to v1.65.0 for arm64 support

### DIFF
--- a/components/kubevirt/kustomization.yaml
+++ b/components/kubevirt/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
 - https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/kubevirt-operator.yaml
 - https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/kubevirt-cr.yaml
-- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.59.0/cdi-cr.yaml
-- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.59.0/cdi-operator.yaml
+- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.65.0/cdi-cr.yaml
+- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.65.0/cdi-operator.yaml
 - virtualmachine-reader-clusterrole.yaml
 - virtualmachine-reader-clusterrolebinding.yaml
 - virtualmachine-reader-serviceaccount.yaml
@@ -16,4 +16,3 @@ resources:
 
 patches:
 - path: patches/feature-gates-patch.yaml
-- path: patches/cdi-workload-nodeselector-patch.yaml

--- a/components/kubevirt/patches/cdi-workload-nodeselector-patch.yaml
+++ b/components/kubevirt/patches/cdi-workload-nodeselector-patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: CDI
-metadata:
-  name: cdi
-spec:
-  workload:
-    nodeSelector:
-      kubernetes.io/arch: "amd64"


### PR DESCRIPTION
The cdi-operator pod has been in CrashLoopBackOff (186 restarts) on rk8s: CDI v1.59.0 images are amd64-only and every rk8s node is arm64 (`exec /usr/bin/cdi-operator: exec format error`). v1.65.0 publishes amd64/arm64/s390x manifests (verified via `podman manifest inspect`). The `cdi-workload-nodeselector-patch` pinning CDI workloads to amd64 is removed — there are no amd64 nodes to pin to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)