### PR TITLE
fix(external-secrets): add ocp-pull vault to onepassword store

### DIFF
--- a/components/external-secrets-operator/onepassword-clustersecretstore.yaml
+++ b/components/external-secrets-operator/onepassword-clustersecretstore.yaml
@@ -1,9 +1,9 @@
 # The `onepassword` store every ExternalSecret in this repo references.
 # Items resolve by name across the listed vaults in priority order
-# (e.g. tailscale-operator's `tailscale-oauth`). The Connect token secret
-# is NOT in git — it is seeded at bootstrap by igou-ansible
+# (e.g. tailscale-operator's `tailscale-oauth` in ocp-pull). The Connect
+# token secret is NOT in git — it is seeded at bootstrap by igou-ansible
 # playbooks/kubernetes/bootstrap-gitops.yaml (step 2 of docs/bootstrap.md);
-# the token needs read on both vaults.
+# the token needs read on all listed vaults.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
@@ -17,6 +17,7 @@ spec:
       vaults:
         awx: 1
         claude: 2
+        ocp-pull: 3
       auth:
         secretRef:
           connectTokenSecretRef:


### PR DESCRIPTION
The `tailscale-oauth` item lives in the `ocp-pull` vault, but the rk8s `onepassword` ClusterSecretStore only resolved `awx` and `claude` — so the tailscale-operator `operator-oauth` ExternalSecret has failed since bootstrap with `key not found in 1Password Vaults: tailscale-oauth in: map[awx:1 claude:2]`.

Note: the rk8s Connect token must have read access to `ocp-pull` for this to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)