### PR TITLE
metallb: split tier pools into rk8s's half (disjoint from ocp)

### DIFF
--- a/components/metallb/ipaddresspools.yaml
+++ b/components/metallb/ipaddresspools.yaml
@@ -1,8 +1,20 @@
 # Three BGP-advertised tiers; rb5009 enforces per-tier client isolation in
-# its forward chain (see igou-inventory #32). 10.10.150.1 is reserved by
+# its forward chain (see igou-inventory #32). 10.10.150.129 is reserved by
 # convention for the cluster ingress/gateway — *.rk8s.igou.systems and the
-# rk8s.igou.systems apex resolve to it (igou-inventory #41); pin it with
+# rk8s.igou.systems apex resolve to it (igou-inventory); pin it with
 # metallb.io/loadBalancerIPs on the gateway's LoadBalancer service.
+#
+# CLUSTER SPLIT (2026-07): rb5009's BGP listener carries both rk8s and ocp
+# (both peer as AS 64513), and igou-openshift claims the same three /24s. To
+# keep the two clusters from handing out or announcing the same address,
+# each tier is split at the /25 boundary with a single uniform rule:
+#   ocp  owns the LOW  half of every tier (10.10.15x.0/25,   .1-.127)
+#   rk8s owns the HIGH half of every tier (10.10.15x.128/25, .129-.254)
+# ocp's live services (hermes 150.1, jellyfin 152.1, dmz-gw 152.3) all sit
+# in the low half, so rk8s took the high half and its gateway VIP moved off
+# the contested 10.10.150.1 to 10.10.150.129 — no address now collides.
+# rb5009's metallb-in filter enforces the split
+# (igou-inventory chore/rb5009-metallb-tier-filter).
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -12,13 +24,13 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   addresses:
-    # .1 is reserved for the cluster gateway (DNS *.rk8s.igou.systems);
-    # exclude it and the network/broadcast addresses from auto-assignment.
-    - 10.10.150.2-10.10.150.254
+    # High half; .129 is the pinned gateway VIP (below), so auto-assign
+    # starts at .130. Low half (.1-.127) belongs to ocp.
+    - 10.10.150.130-10.10.150.254
   autoAssign: true
 ---
 # Pinned pool for the gateway VIP: request it with
-# metallb.io/loadBalancerIPs: 10.10.150.1 (or spec.loadBalancerIP).
+# metallb.io/loadBalancerIPs: 10.10.150.129 (or spec.loadBalancerIP).
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -28,7 +40,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   addresses:
-    - 10.10.150.1/32
+    - 10.10.150.129/32
   autoAssign: false
 ---
 apiVersion: metallb.io/v1beta1
@@ -40,7 +52,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   addresses:
-    - 10.10.151.1-10.10.151.254
+    # High half; low half (.1-.127) belongs to ocp.
+    - 10.10.151.129-10.10.151.254
   autoAssign: false
 ---
 apiVersion: metallb.io/v1beta1
@@ -52,5 +65,6 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   addresses:
-    - 10.10.152.1-10.10.152.254
+    # High half; ocp holds the low half (.1 jellyfin, .3 dmz gateway).
+    - 10.10.152.129-10.10.152.254
   autoAssign: false


### PR DESCRIPTION
Narrows the rk8s MetalLB tier pools to their high /25 half (gateway VIP now 10.10.150.129) so they no longer overlap ocp's pools on the shared rb5009 BGP fabric.
## Why
rb5009 runs one MetalLB BGP fabric shared by **both** clusters: rk8s boards and ocp nodes all peer as AS 64513, and both repos' pools claim the same three /24s (`10.10.150/151/152.0/24`). The router cannot tell the clusters apart, so nothing stops them from handing out or announcing the **same** address. Live audit (rb5009 route table) showed the overlap already booked on **10.10.150.1** — ocp advertises it (a hermes LB) while rk8s had reserved it as its gateway VIP.

## The split — uniform ocp-low
Every tier splits at the /25 boundary with one rule: **ocp owns the low /25, rk8s owns the high /25.** All live ocp services sit in the low half, so rk8s took the high half and **moved its gateway VIP off the contested `.150.1` to `.150.129`** — which dissolves the collision outright, with no dependency on the hermes migration.

| Tier | ocp (low) | rk8s (high) | live ocp svc |
|---|---|---|---|
| trusted-lan .150 | `.1-.127` | `.129-.254` (`.129` gateway) | .1 hermes |
| iot .151 | `.1-.127` | `.129-.254` | none |
| guest-dmz .152 | `.1-.127` | `.129-.254` | .1 jellyfin, .3 dmz-gw |

## Coordination — merge together, in order
1. **igou-inventory** `chore/rb5009-metallb-tier-filter` → apply via `routeros_configure_check` first; verify board sessions bind to the `metallb-rk8s` /29 listener; it also re-points `*.rk8s` DNS to `.150.129`.
2. **igou-kubernetes** + **igou-openshift** pool splits (Argo auto-sync; all live IPs stay in-pool → non-disruptive).

No remaining operator-gated blocker: hermes stays on `.150.1` (now cleanly inside ocp's low /25), and the rk8s Gateway can be created on `.150.129` whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsKPv4Gq1Ftbc3rsBAvbvv