### PR TITLE
feat(external-secrets): migrate rk8s to per-entity Connect token stores

### DIFF
--- a/clusters/internal/democratic-csi/democratic-csi-iscsi-config-externalsecret.yaml
+++ b/clusters/internal/democratic-csi/democratic-csi-iscsi-config-externalsecret.yaml
@@ -1,4 +1,4 @@
-# Templated from the `truenas` item in the ocp-pull vault; requires the
+# Templated from the `truenas` item in the lab_rk8s vault; requires the
 # truenas_csi_api_key_rk8s field (user-linked key of the dedicated
 # TrueNAS `csi` account — same account model as igou-openshift).
 # nameSuffix -rk8s keeps iSCSI target names disjoint from ocp's (-ocp).
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-rk8s
   target:
     name: democratic-csi-iscsi-config
     creationPolicy: Owner

--- a/clusters/internal/democratic-csi/democratic-csi-nfs-config-externalsecret.yaml
+++ b/clusters/internal/democratic-csi/democratic-csi-nfs-config-externalsecret.yaml
@@ -1,4 +1,4 @@
-# Templated from the `truenas` item in the ocp-pull vault; requires the
+# Templated from the `truenas` item in the lab_rk8s vault; requires the
 # truenas_csi_api_key_rk8s field (user-linked key of the dedicated
 # TrueNAS `csi` account — same account model as igou-openshift).
 apiVersion: external-secrets.io/v1
@@ -10,7 +10,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-rk8s
   target:
     name: democratic-csi-nfs-config
     creationPolicy: Owner

--- a/components/external-secrets-operator/kustomization.yaml
+++ b/components/external-secrets-operator/kustomization.yaml
@@ -3,7 +3,8 @@ kind: Kustomization
 namespace: external-secrets
 resources:
   - external-secrets-namespace.yaml
-  - onepassword-sdk-ocp-pull-clustersecretstore.yaml
+  - onepassword-lab-rk8s-clustersecretstore.yaml
+  - onepassword-lab-external-api-keys-clustersecretstore.yaml
 helmCharts:
 - name: external-secrets
   includeCRDs: true

--- a/components/external-secrets-operator/onepassword-lab-external-api-keys-clustersecretstore.yaml
+++ b/components/external-secrets-operator/onepassword-lab-external-api-keys-clustersecretstore.yaml
@@ -1,0 +1,30 @@
+# Read-only store for the lab_external_api_keys vault — holds the
+# tailscale-operator OAuth client (tailscale-oauth). Part of the
+# per-entity Connect token migration; replaces the old
+# onepassword-sdk-ocp-pull store for this ExternalSecret.
+# Unlike ocp (in-cluster Service), rk8s reaches the Connect server —
+# which runs on ocp — via its public edge Route.
+# The Connect token secret is NOT in git — it is seeded at bootstrap by
+# igou-ansible playbooks/kubernetes/bootstrap-gitops.yaml (step 2 of
+# docs/bootstrap.md); the token needs read on the vault below.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-external-api-keys
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: https://onepassword-connect-onepassword-connect.apps.ocp.igou.systems
+      vaults:
+        lab_external_api_keys: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            namespace: external-secrets
+            key: token

--- a/components/external-secrets-operator/onepassword-lab-rk8s-clustersecretstore.yaml
+++ b/components/external-secrets-operator/onepassword-lab-rk8s-clustersecretstore.yaml
@@ -1,6 +1,7 @@
-# Read-only store for the ocp-pull vault. Mirrors igou-openshift's
-# per-vault store layout and naming so ExternalSecret manifests port
-# between the two repos without editing secretStoreRef.
+# Read-write store for the lab_rk8s vault — rk8s's own context vault
+# (rk8s-kubeconfig lives here too). Part of the per-entity Connect token
+# migration: rk8s holds one token scoped to the lab_* vaults it needs, so
+# this replaces the old cross-entity onepassword-sdk-ocp-pull store.
 # Unlike ocp (in-cluster Service), rk8s reaches the Connect server —
 # which runs on ocp — via its public edge Route.
 # The Connect token secret is NOT in git — it is seeded at bootstrap by
@@ -9,7 +10,7 @@
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: onepassword-sdk-ocp-pull
+  name: onepassword-lab-rk8s
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -20,7 +21,7 @@ spec:
     onepassword:
       connectHost: https://onepassword-connect-onepassword-connect.apps.ocp.igou.systems
       vaults:
-        ocp-pull: 1
+        lab_rk8s: 1
       auth:
         secretRef:
           connectTokenSecretRef:

--- a/components/tailscale-operator/operator-oauth-externalsecret.yaml
+++ b/components/tailscale-operator/operator-oauth-externalsecret.yaml
@@ -9,7 +9,7 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   secretStoreRef:
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-external-api-keys
     kind: ClusterSecretStore
   refreshInterval: 24h
   dataFrom:


### PR DESCRIPTION
Migrates rk8s off the shared `onepassword-sdk-ocp-pull` store (vault `ocp-pull`, which the rk8s entity token cannot read) to per-vault stores, mirroring igou-openshift:
- `onepassword-lab-rk8s` — truenas CSI config
- `onepassword-lab-external-api-keys` — tailscale-operator OAuth

The 3 ExternalSecrets are repointed; the `truenas` and `tailscale-oauth` items are copied into the lab_* vaults (least-privilege field subset). `deletionPolicy: Retain` keeps the live secrets during cutover.

⚠ **Requires the rk8s entity token seeded** into `external-secrets/onepassword-connect-token` (the current token is the revoked old shared token — store is already InvalidProviderConfig). Stores validate + ES resync once reseeded.