### PR TITLE
feat(storage): persist Prometheus/Alertmanager, pin Loki PVC to TrueNAS

### DIFF
--- a/components/kube-prometheus-stack/kustomization.yaml
+++ b/components/kube-prometheus-stack/kustomization.yaml
@@ -22,10 +22,34 @@ helmCharts:
         ruleSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
         retention: 30d
+        # Durable TSDB on TrueNAS (democratic-csi iSCSI); without this the
+        # 30d retention above only ever holds until the pod restarts.
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: freenas-iscsi-ssd-csi
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 50Gi
 
+    alertmanager:
+      alertmanagerSpec:
+        # Persist silences + notification dedup state across restarts.
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: freenas-iscsi-ssd-csi
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+
+    # Grafana ships disabled here; a dedicated Grafana operator will own it.
     grafana:
-      enabled: true
-      defaultDashboardsTimezone: America/New_York
+      enabled: false
 
     # k3s runs these control-plane components in-process; there are no
     # separate pods/endpoints to scrape.

--- a/components/loki/kustomization.yaml
+++ b/components/loki/kustomization.yaml
@@ -33,6 +33,7 @@ helmCharts:
       replicas: 1
       persistence:
         enabled: true
+        storageClass: freenas-iscsi-ssd-csi
         size: 20Gi
 
     # Zero out the scalable-mode targets; SingleBinary handles everything.


### PR DESCRIPTION
## Summary
Fixes observability apps that declared (or implied) durable storage but weren't actually landing data on TrueNAS.

- **Prometheus**: had `retention: 30d` but no `storageSpec` → TSDB in `emptyDir`, wiped on every restart. Now a 50Gi PVC on `freenas-iscsi-ssd-csi`.
- **Alertmanager**: no storage → silences + dedup state lost on restart. Now a 2Gi PVC on `freenas-iscsi-ssd-csi`.
- **Loki**: persistence was enabled but no `storageClass` pinned → risked node-local `local-path`. Now pinned to `freenas-iscsi-ssd-csi`.
- **Grafana**: disabled in kube-prometheus-stack; a dedicated Grafana operator will own it later.

## Validation
`make test` — all 13 targets pass (yamllint, helm lint, kustomize build, kubeconform). Rendered output confirms the PVCs and StorageClass pins; zero Grafana resources.

## Rollout notes
On sync, Prometheus/Alertmanager pods roll from `emptyDir` into new PVCs (no in-memory data migrates — there was nothing durable before). democratic-csi provisions zvols on TrueNAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)