### PR TITLE
fix(metallb): client-side diff so pool-boundary changes can sync

### DIFF
--- a/groups/all/values.yaml
+++ b/groups/all/values.yaml
@@ -57,7 +57,14 @@ applications:
 
   metallb:
     annotations:
-      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      # ServerSideDiff=false: MetalLB's ipaddresspool validating webhook
+      # rejects the server-side-diff dry-run whenever a pool-boundary change
+      # transiently overlaps the live pools (e.g. moving the gateway VIP into
+      # a range the old pool still spans), wedging the app at ComparisonError.
+      # Client-side diff skips the dry-run; the sync then applies in name
+      # order (trusted-lan narrows before trusted-lan-gateway moves), which
+      # the webhook accepts.
+      argocd.argoproj.io/compare-options: IgnoreExtraneous,ServerSideDiff=false
       argocd.argoproj.io/sync-wave: '5'
     destination:
       namespace: metallb-system


### PR DESCRIPTION
## Problem
#883's MetalLB pool split merged but never applied to the live rk8s cluster. Argo wedges at `ComparisonError`:

> error calculating server side diff: ... admission webhook `ipaddresspoolvalidationwebhook.metallb.io` denied the request for IPAddressPool/trusted-lan-gateway

Argo's **server-side diff** dry-runs the desired `trusted-lan-gateway` (`10.10.150.129/32`) against the live cluster, where `trusted-lan` is still the pre-split `.2-.254` (which contains `.129`). MetalLB's webhook rejects the transient overlap, so the diff never completes and the merged change can't sync.

## Fix
Disable server-side diff for the metallb app (`compare-options: ...,ServerSideDiff=false`). Client-side diff doesn't dry-run-apply, so the webhook isn't consulted during comparison. The sync then applies IPAddressPools in name order — `trusted-lan` (→`.130-.254`) before `trusted-lan-gateway` (→`.129/32`) — which the webhook accepts because the overlap is already gone by the time the gateway is applied.

Also prevents this whole class of deadlock on any future pool-boundary change. Low-risk/reversible; client-side diff was Argo's default before SSD and handles these simple CRs fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsKPv4Gq1Ftbc3rsBAvbvv