### PR TITLE
feat: expose Prometheus /federate via Gateway API + TLS for OCP UWM federation

### DIFF
--- a/clusters/internal/values.yaml
+++ b/clusters/internal/values.yaml
@@ -36,6 +36,19 @@ applications:
     source:
       path: components/loki
 
+  gateway:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      # After cert-manager/metallb/NGF (wave 5-6) and kube-prometheus-stack
+      # (wave 10, which owns the monitoring namespace + prometheus Service
+      # this app's HTTPRoute and namespace label depend on). ArgoCD retries
+      # cover any residual ordering gaps.
+      argocd.argoproj.io/sync-wave: '15'
+    destination:
+      namespace: nginx-gateway
+    source:
+      path: components/gateway
+
   tailscale-operator:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous

--- a/components/gateway/cluster-acme-clusterissuer.yaml
+++ b/components/gateway/cluster-acme-clusterissuer.yaml
@@ -1,0 +1,27 @@
+---
+# First ClusterIssuer on rk8s. Named to match the ocp cluster's issuer
+# (`cluster-acme`) so the two clusters read the same. Let's Encrypt prod,
+# solving DNS01 via Cloudflare using the `dns-token` Secret above.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-acme
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  acme:
+    email: igou.david@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: acme-private-key
+    solvers:
+      - dns01:
+          cloudflare:
+            email: igou.david@gmail.com
+            apiTokenSecretRef:
+              name: dns-token
+              key: credential
+        selector:
+          dnsZones:
+            - igou.systems
+            - rk8s.igou.systems

--- a/components/gateway/dns-token-externalsecret.yaml
+++ b/components/gateway/dns-token-externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# Cloudflare API token for cert-manager's DNS01 ACME solver. Materialised
+# into ns cert-manager as Secret `dns-token` (key `credential`) so the
+# ClusterIssuer's apiTokenSecretRef can resolve it.
+#
+# There is no rk8s-specific Cloudflare token item in lab_external_api_keys,
+# so this reuses `dns-token-ocp` — the exact same item the ocp cluster's
+# issuer consumes (igou-openshift components/cert-manager-operator). One
+# Cloudflare token, two clusters; nothing rk8s-specific to mint.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dns-token
+  namespace: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-lab-external-api-keys
+  target:
+    name: dns-token
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: dns-token-ocp

--- a/components/gateway/federate-httproute.yaml
+++ b/components/gateway/federate-httproute.yaml
@@ -1,0 +1,35 @@
+---
+# Exposes ONLY Prometheus /federate over the trusted-lan Gateway, at
+# federate.rk8s.igou.systems, for the ocp cluster's UWM to scrape. The path
+# prefix is deliberately limited to /federate: TLS terminates at the Gateway
+# but there is no auth in front of it, so we expose the federation endpoint
+# and nothing else of the Prometheus UI/API — trusted LAN + path-limited.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prometheus-federate
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  # group/kind/weight below are API-server defaults, stated explicitly so
+  # ArgoCD's server-side-apply diff doesn't report the route as forever
+  # OutOfSync (same wart as the Gateway certificateRefs).
+  parentRefs:
+    - name: trusted-lan
+      namespace: nginx-gateway
+      group: gateway.networking.k8s.io
+      kind: Gateway
+  hostnames:
+    - federate.rk8s.igou.systems
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /federate
+      backendRefs:
+        - name: kube-prometheus-stack-prometheus
+          port: 9090
+          group: ""
+          kind: Service
+          weight: 1

--- a/components/gateway/kustomization.yaml
+++ b/components/gateway/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No top-level `namespace:` — resources span cert-manager, nginx-gateway,
+# and monitoring, each pinned in its own manifest.
+resources:
+  - dns-token-externalsecret.yaml
+  - cluster-acme-clusterissuer.yaml
+  - wildcard-rk8s-certificate.yaml
+  - trusted-lan-gateway.yaml
+  - federate-httproute.yaml

--- a/components/gateway/trusted-lan-gateway.yaml
+++ b/components/gateway/trusted-lan-gateway.yaml
@@ -13,10 +13,10 @@ spec:
   gatewayClassName: nginx
   infrastructure:
     # Copied by NGF onto the generated LoadBalancer Service. The VIP is a
-    # contract with rb5009 (igou-inventory): the rk8s apex and one EXPLICIT
-    # A record per exposed hostname resolve to 10.10.150.129 (no *.rk8s DNS
-    # wildcard — dropped in igou-inventory#132; a new HTTPRoute hostname
-    # needs a matching A record there). The VIP is the reserved
+    # contract with rb5009 (igou-inventory): one EXPLICIT A record per
+    # exposed hostname resolves to 10.10.150.129 (no *.rk8s DNS wildcard or
+    # apex — dropped in igou-inventory#132; a new HTTPRoute hostname needs a
+    # matching A record there). The VIP is the reserved
     # `trusted-lan-gateway` MetalLB pool (components/metallb). Do not change
     # it without updating both repos.
     annotations:

--- a/components/gateway/trusted-lan-gateway.yaml
+++ b/components/gateway/trusted-lan-gateway.yaml
@@ -1,0 +1,46 @@
+---
+# First Gateway on rk8s. NGF (gatewayClassName `nginx`) provisions the
+# data-plane LoadBalancer Service in this namespace when it reconciles this
+# Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: trusted-lan
+  namespace: nginx-gateway
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  gatewayClassName: nginx
+  infrastructure:
+    # Copied by NGF onto the generated LoadBalancer Service. The VIP is a
+    # contract with rb5009 (igou-inventory): *.rk8s.igou.systems and the
+    # apex resolve to 10.10.150.129, and it is the reserved
+    # `trusted-lan-gateway` MetalLB pool (components/metallb). Do not change
+    # it without updating both repos.
+    annotations:
+      metallb.universe.tf/address-pool: trusted-lan-gateway
+      metallb.universe.tf/loadBalancerIPs: 10.10.150.129
+  listeners:
+    - name: https
+      hostname: "*.rk8s.igou.systems"
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          # kind/group are API-server defaults, stated explicitly so
+          # ArgoCD's server-side-apply diff doesn't report the Gateway as
+          # forever OutOfSync.
+          - name: wildcard-rk8s-tls
+            kind: Secret
+            group: ""
+      # Apps opt in by labelling their namespace `gateway-access/trusted-lan:
+      # "true"` and creating an HTTPRoute with parentRefs to this Gateway.
+      # Anything routed here is reachable by every VLAN rb5009 admits to the
+      # trusted-lan tier VIP.
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              gateway-access/trusted-lan: "true"

--- a/components/gateway/trusted-lan-gateway.yaml
+++ b/components/gateway/trusted-lan-gateway.yaml
@@ -13,8 +13,10 @@ spec:
   gatewayClassName: nginx
   infrastructure:
     # Copied by NGF onto the generated LoadBalancer Service. The VIP is a
-    # contract with rb5009 (igou-inventory): *.rk8s.igou.systems and the
-    # apex resolve to 10.10.150.129, and it is the reserved
+    # contract with rb5009 (igou-inventory): the rk8s apex and one EXPLICIT
+    # A record per exposed hostname resolve to 10.10.150.129 (no *.rk8s DNS
+    # wildcard — dropped in igou-inventory#132; a new HTTPRoute hostname
+    # needs a matching A record there). The VIP is the reserved
     # `trusted-lan-gateway` MetalLB pool (components/metallb). Do not change
     # it without updating both repos.
     annotations:

--- a/components/gateway/wildcard-rk8s-certificate.yaml
+++ b/components/gateway/wildcard-rk8s-certificate.yaml
@@ -1,0 +1,29 @@
+---
+# Wildcard cert for every trusted-lan hostname (federate.rk8s.igou.systems
+# and any future *.rk8s.igou.systems route). DNS01 supports wildcards.
+# Lives in the Gateway's namespace (nginx-gateway) so the listener
+# certificateRef needs no ReferenceGrant.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-rk8s-tls
+  namespace: nginx-gateway
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  secretName: wildcard-rk8s-tls
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
+  subject:
+    organizations:
+      - Igou
+  privateKey:
+    size: 4096
+    algorithm: RSA
+    encoding: PKCS1
+    rotationPolicy: Always
+  dnsNames:
+    - "*.rk8s.igou.systems"
+  issuerRef:
+    kind: ClusterIssuer
+    name: cluster-acme

--- a/components/kube-prometheus-stack/kustomization.yaml
+++ b/components/kube-prometheus-stack/kustomization.yaml
@@ -15,6 +15,12 @@ helmCharts:
 
     prometheus:
       prometheusSpec:
+        # Stamped onto every series this Prometheus exposes, including over
+        # /federate. Lets the OCP UWM federation scrape attribute pulled-in
+        # series to this source cluster (cross-cluster federation, see the
+        # gateway component + igou-openshift UWM additionalScrapeConfig).
+        externalLabels:
+          cluster: rk8s
         # Pick up all ServiceMonitors/PodMonitors/Rules cluster-wide, not
         # just the ones with the chart's release label.
         serviceMonitorSelectorNilUsesHelmValues: false

--- a/components/kube-prometheus-stack/monitoring-namespace.yaml
+++ b/components/kube-prometheus-stack/monitoring-namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
+  labels:
+    # Opt this namespace into the trusted-lan Gateway (components/gateway):
+    # the Gateway's allowedRoutes selects namespaces carrying this label, so
+    # the /federate HTTPRoute here is permitted to attach.
+    gateway-access/trusted-lan: "true"

--- a/components/metallb/ipaddresspools.yaml
+++ b/components/metallb/ipaddresspools.yaml
@@ -1,9 +1,9 @@
 # Three BGP-advertised tiers; rb5009 enforces per-tier client isolation in
 # its forward chain (see igou-inventory #32). 10.10.150.129 is reserved by
-# convention for the cluster ingress/gateway — the rk8s.igou.systems apex
-# plus one explicit A record per exposed hostname resolve to it (no *.rk8s
-# DNS wildcard since igou-inventory#132); pin it with
-# metallb.io/loadBalancerIPs on the gateway's LoadBalancer service.
+# convention for the cluster ingress/gateway — one explicit A record per
+# exposed hostname resolves to it (no *.rk8s DNS wildcard or apex since
+# igou-inventory#132); pin it with metallb.io/loadBalancerIPs on the
+# gateway's LoadBalancer service.
 #
 # CLUSTER SPLIT (2026-07): rb5009's BGP listener carries both rk8s and ocp
 # (both peer as AS 64513), and igou-openshift claims the same three /24s. To

--- a/components/metallb/ipaddresspools.yaml
+++ b/components/metallb/ipaddresspools.yaml
@@ -1,7 +1,8 @@
 # Three BGP-advertised tiers; rb5009 enforces per-tier client isolation in
 # its forward chain (see igou-inventory #32). 10.10.150.129 is reserved by
-# convention for the cluster ingress/gateway — *.rk8s.igou.systems and the
-# rk8s.igou.systems apex resolve to it (igou-inventory); pin it with
+# convention for the cluster ingress/gateway — the rk8s.igou.systems apex
+# plus one explicit A record per exposed hostname resolve to it (no *.rk8s
+# DNS wildcard since igou-inventory#132); pin it with
 # metallb.io/loadBalancerIPs on the gateway's LoadBalancer service.
 #
 # CLUSTER SPLIT (2026-07): rb5009's BGP listener carries both rk8s and ocp


### PR DESCRIPTION
## What / why

Publishes the rk8s cluster's Prometheus `/federate` endpoint over TLS so the **OCP cluster's User Workload Monitoring can scrape it cross-cluster** (the OCP side is a separate PR by another agent). This is the rk8s half of the cross-cluster federation project.

## Bootstrap nature

This cluster had **zero** Gateway / HTTPRoute / ClusterIssuer / Certificate resources — these are the **first** ones. NGINX Gateway Fabric (v2.6.3), cert-manager (v1.20.3), MetalLB, and external-secrets were already deployed but unused for ingress; this PR wires them together.

## The chain (VIP → DNS → cert → route)

- **VIP**: the `trusted-lan` Gateway pins its NGF-provisioned LoadBalancer Service to the reserved cluster gateway VIP **10.10.150.129** via `spec.infrastructure.annotations` (`metallb.universe.tf/address-pool: trusted-lan-gateway` + `metallb.universe.tf/loadBalancerIPs`). That pool (`components/metallb`) is `autoAssign: false` and exists solely for this VIP.
- **Cert**: `cluster-acme` ClusterIssuer (Let's Encrypt **prod**, DNS01 via Cloudflare) issues a wildcard `*.rk8s.igou.systems` Certificate into the Gateway's namespace (`nginx-gateway`), so the listener `certificateRef` needs no ReferenceGrant. DNS01 supports wildcards and does not depend on the A record resolving.
- **Route**: an HTTPRoute in `monitoring` (host `federate.rk8s.igou.systems`) attaches to the Gateway and forwards to `kube-prometheus-stack-prometheus:9090`. The `monitoring` namespace is labelled `gateway-access/trusted-lan: "true"` so the Gateway's `allowedRoutes` selector admits it.

## `/federate`-only path restriction (rationale)

The HTTPRoute matches **only** `PathPrefix: /federate`. TLS terminates at the Gateway but there is **no auth** in front of it — exposure is gated by (a) trusted-LAN reachability (rb5009 tier isolation to the VIP) and (b) the path limit, so only the federation endpoint is reachable, not the rest of the Prometheus UI/API.

## externalLabels

Added `prometheus.prometheusSpec.externalLabels.cluster: rk8s` so every series pulled via `/federate` is attributable to this source cluster downstream in OCP UWM.

## Token-item choice

There is **no rk8s-specific Cloudflare token** in the `lab_external_api_keys` 1Password vault. The `dns-token` ExternalSecret therefore **reuses `dns-token-ocp`** — the exact same item the OCP cluster's issuer consumes — materialising Secret `dns-token` (key `credential`) in `cert-manager`. One Cloudflare token, two clusters.

## DNS (resolved via igou-inventory#159)

Originally a blocker: `federate.rk8s.igou.systems` had no A record — igou-inventory#132 deliberately dropped the `*.rk8s` wildcard + apex in favour of explicit per-hostname tier records. **igou-inventory#159 (merged) adds the explicit `federate.rk8s.igou.systems -> 10.10.150.129` record**, applied to rb5009 via the routeros config-as-code play. The stale unmanaged on-device apex record (`rk8s.igou.systems -> 10.10.150.1`, now ocp's hermes-ssh VIP) is #132's pending manual cleanup — removed by hand per that PR's runbook (its documented cleanup command only matched regexp-type records, which is why the name-type apex survived). Comments in this PR were updated to state the explicit-record convention instead of the stale wildcard claim.

## Sync wave

Registered as app `gateway` in `clusters/internal/values.yaml` at **sync-wave 15** — after cert-manager/MetalLB (5), NGF (6), and kube-prometheus-stack (10, which owns the `monitoring` namespace + prometheus Service). ArgoCD retries cover residual ordering gaps.

## ArgoCD SSA drift gotcha

Mirrors the OCP gateway-api convention: `certificateRefs[].kind/group` and `backendRefs[].group/kind/weight` are stated explicitly (they are API-server defaults) so ArgoCD's server-side-apply diff does not report the Gateway/HTTPRoute as forever OutOfSync.

## Validation

- `make lint` (yamllint) → pass
- `make validate-kustomize` (kustomize `--enable-helm`) → `components/gateway`, `components/kube-prometheus-stack` ✅
- Rendered Prometheus CR carries `externalLabels: {cluster: rk8s}`; `monitoring` ns carries the gateway-access label.

## Post-merge verification

Once ArgoCD syncs, the cert is Ready, and DNS resolves:

```
curl -sG https://federate.rk8s.igou.systems/federate \
  --data-urlencode 'match[]={job="node-exporter"}'
```

Should return Prometheus federation exposition-format series carrying `cluster="rk8s"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UuTBEb3CiUhuYRDDT4nKx
