### PR TITLE
feat(envoy-gateway): Envoy Gateway v1.8.2 as the rk8s L7 ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Helm chart via kustomize's `helmCharts` field, plus any raw manifests
 | external-secrets-operator | charts.external-secrets.io | 0 |
 | cert-manager | charts.jetstack.io | 5 |
 | nginx-gateway-fabric | ghcr.io/nginx/charts (OCI) | 6 |
+| envoy-gateway | docker.io/envoyproxy (OCI) | 6 |
 | democratic-csi | democratic-csi.github.io/charts | 7 |
 | kube-prometheus-stack | prometheus-community.github.io/helm-charts | 10 |
 | loki | grafana.github.io/helm-charts | 11 |
@@ -41,6 +42,9 @@ Not yet configured (intentionally):
 - **external-secrets** has no ClusterSecretStore; the `onepassword` store and
   its backend still need to be wired up. Until then anything that consumes an
   ExternalSecret (tailscale-operator oauth, private repo creds) stays degraded.
+- **envoy-gateway** serves HTTP only; TLS waits on a cluster issuer
+  (see [docs/envoy-gateway.md](docs/envoy-gateway.md)). The Gateway API CRDs
+  remain owned by the nginx-gateway-fabric app.
 
 ## Bootstrap
 

--- a/clusters/internal/envoy-gateway/envoyproxy.yaml
+++ b/clusters/internal/envoy-gateway/envoyproxy.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: rk8s-proxy-config
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 2
+        container:
+          # Sized for the arm64 SBC fleet; bump if the gateway ever
+          # fronts something hungrier than homelab HTTP traffic.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+      envoyService:
+        # 10.10.150.129 is the rk8s ingress VIP by convention:
+        # *.rk8s.igou.systems and the apex resolve to it, and the
+        # trusted-lan-gateway MetalLB pool reserves it (autoAssign off).
+        annotations:
+          metallb.io/loadBalancerIPs: 10.10.150.129
+        # Local keeps client source IPs and, with MetalLB BGP mode,
+        # announces the VIP only from nodes running a proxy pod.
+        externalTrafficPolicy: Local

--- a/clusters/internal/envoy-gateway/gateway.yaml
+++ b/clusters/internal/envoy-gateway/gateway.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: rk8s
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: envoy
+  # HTTP only for now: no ClusterIssuer exists on rk8s yet. When one
+  # lands, add a 443 HTTPS listener with tls.certificateRefs and let
+  # cert-manager's Gateway API integration (already enabled in the
+  # cert-manager component) issue the wildcard cert.
+  listeners:
+    - name: http-wildcard
+      protocol: HTTP
+      port: 80
+      hostname: "*.rk8s.igou.systems"
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: http-apex
+      protocol: HTTP
+      port: 80
+      hostname: rk8s.igou.systems
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/clusters/internal/envoy-gateway/gatewayclass.yaml
+++ b/clusters/internal/envoy-gateway/gatewayclass.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  # Cluster-wide data-plane defaults (MetalLB VIP pinning, replicas,
+  # resource sizing) live on the EnvoyProxy CR.
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: rk8s-proxy-config
+    namespace: envoy-gateway-system

--- a/clusters/internal/envoy-gateway/kustomization.yaml
+++ b/clusters/internal/envoy-gateway/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: envoy-gateway-system
+resources:
+  - ../../../components/envoy-gateway
+  - gatewayclass.yaml
+  - envoyproxy.yaml
+  - gateway.yaml
+# The GatewayClass/EnvoyProxy/Gateway CRs sync in the same operation as
+# the CRDs that define them; skip the dry-run so the first sync doesn't
+# fail on not-yet-registered kinds (same pattern as democratic-csi).
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/clusters/internal/values.yaml
+++ b/clusters/internal/values.yaml
@@ -9,6 +9,15 @@ applications:
     source:
       path: clusters/internal
 
+  envoy-gateway:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '6'
+    destination:
+      namespace: envoy-gateway-system
+    source:
+      path: clusters/internal/envoy-gateway
+
   democratic-csi:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous

--- a/components/envoy-gateway/envoy-gateway-namespace.yaml
+++ b/components/envoy-gateway/envoy-gateway-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: envoy-gateway-system

--- a/components/envoy-gateway/envoy-gateway-servicemonitor.yaml
+++ b/components/envoy-gateway/envoy-gateway-servicemonitor.yaml
@@ -1,0 +1,12 @@
+# Control-plane metrics (xDS translation, watch queues, etc.) on the
+# envoy-gateway Service's metrics port (19001).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: envoy-gateway
+spec:
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway
+  endpoints:
+    - port: metrics

--- a/components/envoy-gateway/envoy-proxy-podmonitor.yaml
+++ b/components/envoy-gateway/envoy-proxy-podmonitor.yaml
@@ -1,0 +1,16 @@
+# Data-plane metrics. Envoy Gateway generates the proxy Deployments at
+# runtime (they are not in git), so scrape the pods by the labels the
+# infra manager stamps on them. Envoy serves Prometheus metrics on
+# 19001 /stats/prometheus by default.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-proxy-fleet
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: envoy
+      app.kubernetes.io/managed-by: envoy-gateway
+  podMetricsEndpoints:
+    - targetPort: 19001
+      path: /stats/prometheus

--- a/components/envoy-gateway/kustomization.yaml
+++ b/components/envoy-gateway/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: envoy-gateway-system
+resources:
+  - envoy-gateway-namespace.yaml
+  - envoy-gateway-servicemonitor.yaml
+  - envoy-proxy-podmonitor.yaml
+helmCharts:
+# Envoy Gateway's own CRDs (gateway.envoyproxy.io) only. The Gateway API
+# CRDs (gateway.networking.k8s.io) are deliberately NOT installed here:
+# the nginx-gateway-fabric app already owns the standard-channel v1.5.1
+# bundle, and with FailOnSharedResource=true a second owner would fail
+# every sync. See docs/envoy-gateway.md for the CRD ownership plan.
+- name: gateway-crds-helm
+  releaseName: envoy-gateway-crds
+  namespace: envoy-gateway-system
+  version: 1.8.2
+  repo: oci://docker.io/envoyproxy
+  valuesInline:
+    crds:
+      gatewayAPI:
+        enabled: false
+      envoyGateway:
+        enabled: true
+# Control plane. crds.enabled=false keeps this chart from re-installing
+# both CRD sets (its crds subchart bundles the *experimental* Gateway API
+# channel on top of the Envoy Gateway CRDs). The certgen Job carries
+# helm.sh/hook pre-install annotations that Argo CD runs as a PreSync
+# hook; upstream annotates it for exactly this flow.
+- name: gateway-helm
+  releaseName: envoy-gateway
+  namespace: envoy-gateway-system
+  version: 1.8.2
+  repo: oci://docker.io/envoyproxy
+  valuesInline:
+    crds:
+      enabled: false
+    # Topology-aware routing webhook is useless on a single-zone homelab
+    # cluster; disabling it removes a mutating webhook failure mode.
+    topologyInjector:
+      enabled: false

--- a/docs/envoy-gateway.md
+++ b/docs/envoy-gateway.md
@@ -1,0 +1,153 @@
+# Envoy Gateway on rk8s
+
+Spec and operational notes for the `envoy-gateway` component
+(Envoy Gateway v1.8.2, Gateway API implementation).
+
+## Goal
+
+Give rk8s a working L7 ingress: a Gateway API data plane answering on the
+reserved ingress VIP `10.10.150.129`, which `*.rk8s.igou.systems` and the
+`rk8s.igou.systems` apex already resolve to (igou-inventory DNS). Workloads
+expose themselves by creating `HTTPRoute` objects that attach to the shared
+`rk8s` Gateway.
+
+## Current state this builds on
+
+- nginx-gateway-fabric (NGF) is deployed at wave 6 but idle: its
+  GatewayClass `nginx` is Accepted, yet no Gateway or HTTPRoute exists
+  anywhere in the cluster, so it runs no data plane and holds no LB service.
+- The live Gateway API CRDs are the **standard channel v1.5.1** bundle,
+  installed and owned by the NGF app (pinned to the NGF release tag).
+- MetalLB (FRR-K8s, BGP to rb5009) is deployed, `trusted-lan-gateway` pool
+  reserves `10.10.150.129/32` with `autoAssign: false`, and k3s was
+  installed without klipper-lb. No LoadBalancer service exists yet — this
+  gateway is the first consumer.
+- cert-manager runs with `enableGatewayAPI: true`, but no (Cluster)Issuer
+  exists yet.
+
+## Design
+
+### CRD ownership — the one sharp edge
+
+The app-of-apps defaults include `FailOnSharedResource=true`, so exactly one
+Argo app may own any given CRD. The Gateway API CRDs stay with the NGF app
+(standard channel v1.5.1, matching what is live). Envoy Gateway is therefore
+installed in two pieces:
+
+- `gateway-crds-helm` with `crds.gatewayAPI.enabled=false` and
+  `crds.envoyGateway.enabled=true` — installs only the
+  `gateway.envoyproxy.io` CRDs.
+- `gateway-helm` with `crds.enabled=false` — control plane only. Left at
+  its default, that chart's crds subchart would install the *experimental*
+  Gateway API channel over NGF's standard bundle (plus a
+  ValidatingAdmissionPolicy that polices exactly that kind of overwrite).
+
+Envoy Gateway v1.8.2 targets Gateway API v1.5.1, the exact live bundle
+version. On the standard channel EG reconciles HTTPRoute and GRPCRoute;
+TCPRoute/UDPRoute are experimental-only, and TLSRoute — although present in
+standard v1.5.1 as `v1` — is skipped by EG, which still watches the
+`v1alpha3` version (envoyproxy/gateway#8326). HTTP(S) routing is unaffected.
+
+**If/when NGF is retired**: move the Gateway API CRDs into a standalone
+`gateway-api-crds` component *first*, then remove the NGF app. Deleting the
+NGF app while it owns the CRDs risks pruning every `gateways.networking.k8s.io`
+resource with them.
+
+### Component layout
+
+Follows the democratic-csi split: generic install in `components/`,
+cluster-specific config in `clusters/internal/`.
+
+```
+components/envoy-gateway/            # charts, namespace, monitors (portable)
+clusters/internal/envoy-gateway/     # GatewayClass + EnvoyProxy + Gateway
+                                     # (VIP, hostnames — rk8s-specific)
+```
+
+The Argo app (`clusters/internal/values.yaml`, wave 6) points at the
+cluster overlay, which includes the component.
+
+### Data plane
+
+- `GatewayClass envoy` → `parametersRef` → `EnvoyProxy rk8s-proxy-config`.
+- Envoy Gateway generates the proxy Deployment/Service at runtime in
+  `envoy-gateway-system`; they are intentionally not in git and stay
+  untracked by Argo.
+- The generated Service is `type: LoadBalancer` with
+  `metallb.io/loadBalancerIPs: 10.10.150.129` and
+  `externalTrafficPolicy: Local` (real client IPs; MetalLB announces the
+  VIP only from nodes with a ready proxy pod). 2 replicas, sized for the
+  SBC fleet.
+- `topologyInjector` disabled — single-zone cluster, one less mutating
+  webhook.
+
+### Gateway
+
+One shared `Gateway rk8s` with HTTP listeners for `*.rk8s.igou.systems`
+and the apex, `allowedRoutes: All` (project separation is handled at the
+Argo project layer, not by listener namespace policy).
+
+TLS is a deliberate follow-up: there is no issuer on rk8s yet. When one
+exists, add a 443 listener with `tls.certificateRefs` and a cert-manager
+`Certificate` (or Gateway annotation) for `*.rk8s.igou.systems`.
+
+### Monitoring
+
+kube-prometheus-stack selects monitors cluster-wide, so the component ships:
+
+- `ServiceMonitor envoy-gateway` — control-plane metrics :19001.
+- `PodMonitor envoy-proxy-fleet` — Envoy stats `:19001/stats/prometheus`
+  on the generated proxy pods, matched by the infra-manager labels.
+
+### Argo CD mechanics
+
+- certgen Job + RBAC carry `helm.sh/hook: pre-install` annotations that
+  Argo CD executes as PreSync hooks (upstream annotates them for Argo);
+  the Job self-cleans via `ttlSecondsAfterFinished: 30`.
+- The whole cluster overlay gets
+  `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` so
+  first-sync dry-runs don't fail before the EG CRDs register.
+- Big EG CRDs are fine because apps default to `ServerSideApply=true`.
+
+## Using it
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: myapp
+  namespace: myapp
+spec:
+  parentRefs:
+    - name: rk8s
+      namespace: envoy-gateway-system
+  hostnames:
+    - myapp.rk8s.igou.systems
+  rules:
+    - backendRefs:
+        - name: myapp
+          port: 8080
+```
+
+## Verification after first sync
+
+```sh
+kubectl -n envoy-gateway-system get pods                  # controller + 2 envoy proxies
+kubectl get gatewayclass envoy                            # Accepted=True
+kubectl -n envoy-gateway-system get gateway rk8s          # Programmed=True, address 10.10.150.129
+kubectl -n envoy-gateway-system get svc                   # generated LB svc holds the VIP
+curl -H 'Host: anything.rk8s.igou.systems' http://10.10.150.129/   # 404 from Envoy = data path up
+```
+
+If the VIP never leaves `<pending>`, check MetalLB speaker logs and the
+rb5009 `metallb-in` filter (rk8s may only announce the high /25 of each
+tier; `.129` is the low edge of the allowed half).
+
+## Follow-ups
+
+- ClusterIssuer + HTTPS listener + wildcard cert.
+- Decide NGF's fate; if retiring it, do the `gateway-api-crds` component
+  extraction first (see above).
+- Confirm the PodMonitor actually produces targets (the proxy pods must
+  expose 19001; if not, switch to a scrape config on the
+  `prometheus.io/*` annotations EG stamps on proxy pods).


### PR DESCRIPTION
## What

Adds **Envoy Gateway v1.8.2** as the Gateway API implementation actually serving traffic on rk8s, wired to the reserved ingress VIP. Full spec in [`docs/envoy-gateway.md`](https://github.com/igou-io/igou-kubernetes/blob/feat/envoy-gateway/docs/envoy-gateway.md).

- `components/envoy-gateway/` — portable install: `gateway-crds-helm` (Envoy Gateway CRDs **only**) + `gateway-helm` control plane (`crds.enabled=false`, topology-injector webhook off), namespace, control-plane ServiceMonitor, data-plane PodMonitor.
- `clusters/internal/envoy-gateway/` — rk8s-specific overlay (democratic-csi pattern): `GatewayClass envoy` → `EnvoyProxy rk8s-proxy-config` (2 replicas, SBC-sized resources, `metallb.io/loadBalancerIPs: 10.10.150.129`, `externalTrafficPolicy: Local`) and the shared `Gateway rk8s` with HTTP listeners for `*.rk8s.igou.systems` + apex.
- App entry at sync-wave 6 in `clusters/internal/values.yaml`; README table/notes updated.

Workloads onboard by attaching an `HTTPRoute` to `Gateway rk8s` (example in the doc).

## Design decisions (researched against the live cluster)

- **Gateway API CRD ownership**: app defaults include `FailOnSharedResource=true`, so the CRDs must have exactly one owning app. They stay with nginx-gateway-fabric (standard channel **v1.5.1**, live-verified — exactly the Gateway API version EG 1.8.2 targets). The `gateway-helm` crds subchart is disabled because it would overwrite the standard bundle with the *experimental* channel (plus ship a ValidatingAdmissionPolicy that polices that overwrite).
- **NGF untouched**: it's deployed but fully idle (GatewayClass Accepted, zero Gateways/HTTPRoutes, no LB service), so the two implementations coexist safely on distinct GatewayClasses. Retiring NGF is a follow-up — and requires extracting a `gateway-api-crds` component **first** (doc has the plan).
- **Argo mechanics**: certgen Job/RBAC use upstream's `helm.sh/hook: pre-install` annotations (Argo runs them as PreSync; upstream annotates for exactly this); overlay-wide `SkipDryRunOnMissingResource=true` covers CRs syncing alongside their CRDs; huge EG CRDs are fine under the default `ServerSideApply=true`.
- **Networking**: klipper-lb confirmed absent; MetalLB FRR-K8s is live and `trusted-lan-gateway` reserves `10.10.150.129/32` (`autoAssign: false`) — this Gateway is its intended consumer per the pool comments.

## Validation

- `make test` green (yamllint, helm lint, all 15 kustomize builds, kubeconform).
- Rendered overlay inspected: exactly 8 `gateway.envoyproxy.io` CRDs, **zero** `gateway.networking.k8s.io` CRDs, VIP annotation present, everything namespaced to `envoy-gateway-system`.
- Server-side `--dry-run=server` against live rk8s: Gateway, GatewayClass, ServiceMonitor, PodMonitor, and all 8 EG CRDs accepted.

## Caveats

1. **First LoadBalancer service on rk8s, ever.** The MetalLB→rb5009 BGP announcement path is unexercised; if the VIP sticks at `<pending>`/unreachable, check the rb5009 `metallb-in` filter accepts `10.10.150.129` (it's the low edge of rk8s's high /25).
2. **HTTP only.** No ClusterIssuer exists on rk8s; the 443/TLS listener is a documented follow-up (cert-manager already runs with `enableGatewayAPI: true`).
3. **Standard-channel route kinds only.** TCPRoute/UDPRoute are experimental-channel; TLSRoute exists in standard v1.5.1 but EG still watches `v1alpha3` and skips it (envoyproxy/gateway#8326). HTTPRoute/GRPCRoute are fully supported.
4. **PodMonitor is best-effort** until first sync proves the proxy pods expose 19001 as a scrapeable target; if empty, swap to a scrape config using the `prometheus.io/*` annotations EG stamps on proxy pods. Control-plane ServiceMonitor is deterministic.
5. **`externalTrafficPolicy: Local`** preserves client IPs but means only nodes with a ready proxy pod announce the VIP; with 2 replicas across 5 nodes that's fine, but node drains will shift the BGP path.
6. First sync may need a retry while the EG CRDs register before the `EnvoyProxy` CR applies — covered by `SkipDryRunOnMissingResource` + the apps' unlimited retry policy, so expect brief transient sync errors, not failures.

Do **not** merge yet — awaiting review per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Taa2i1LeZsDCdPe8bFjRv5
